### PR TITLE
Add Pharmacy data to Spend and Utilization model in the PMPM mart

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -18,6 +18,10 @@ vars:
                                        # name of the schema where sources
                                        # feeding this project are stored
 
+    pharmacy_schema: tuva_claims_input                 # configuration required
+                                       # name of the schema where sources
+                                       # feeding this project are stored
+
     output_database: transformed_data              # configuration required
                                        # name of the database where output of
                                        # this project should be written
@@ -28,6 +32,7 @@ vars:
 
     encounter: "{{ source(var('source_name'),'encounter') }}"
     coverage: "{{ source(var('source_name'),'coverage') }}"
+    pharmacy_claim: "{{ source(var('source_name'),'pharmacy_claim') }}"
 
 # These configurations specify where dbt should look for different types of files.
 # The `model-paths` config, for example, states that models in this project can be

--- a/models/encounter_spend_and_utilization.sql
+++ b/models/encounter_spend_and_utilization.sql
@@ -1,15 +1,27 @@
 
 {{ config(materialized='table') }}
 
-with encounter as (
-select
-    patient_id
-,   year(encounter_end_date) as year
-,   lpad(month(encounter_end_date),2,0) as month
-,   concat(year(encounter_end_date),lpad(month(encounter_end_date),2,0)) AS year_month
-,   encounter_type
-,   paid_amount
-from {{ var('encounter') }}
+with encounter as 
+(
+    select
+        patient_id
+       ,year(encounter_end_date) as year
+       ,lpad(month(encounter_end_date),2,0) as month
+       ,concat(year(encounter_end_date),lpad(month(encounter_end_date),2,0)) AS year_month
+       ,encounter_type
+       ,paid_amount
+    from {{var('encounter')}}
+)
+, pharmacy as 
+(
+    select
+        patient_id
+        ,year(to_date(dispensing_date, 'YYYY-MM-DD')) as year
+        ,lpad(month(to_date(dispensing_date, 'YYYY-MM-DD')),2,0) as month
+        ,concat(year(to_date(dispensing_date, 'YYYY-MM-DD')),lpad(month(to_date(dispensing_date, 'YYYY-MM-DD')),2,0)) AS year_month
+        ,'pharmacy' as encounter_type
+        ,paid_amount
+    from {{var('pharmacy_claim')}}
 )
 
 select 
@@ -19,6 +31,20 @@ select
     ,count(*) as count_encounters
     ,sum(paid_amount) as paid_amount
 from encounter
+group by 
+    patient_id
+    ,encounter_type
+    ,year_month
+
+union all
+
+select 
+    patient_id
+    ,encounter_type
+    ,year_month
+    ,count(*) as count_encounters
+    ,sum(paid_amount) as paid_amount
+from pharmacy
 group by 
     patient_id
     ,encounter_type

--- a/models/source.yml
+++ b/models/source.yml
@@ -7,3 +7,8 @@ sources:
     tables:
       - name: coverage
       - name: encounter
+  - name: "{{ var('source_name') }}"
+    database: "{{ var('input_database') }}"
+    schema: "{{ var('pharmacy_schema') }}"
+    tables:
+      - name: pharmacy_claim


### PR DESCRIPTION
This PR adds pharmacy data into the spend and utilization model in the PMPM mart. It adds an encounter type of 'pharmacy' for any of the pharmacy claims and maps year months to the dispensing date for pharmacy claims.

The reason for this PR is so that downstream models can pull just from this one table in pmpm to get all the utilization and spend including both medical and pharmacy.